### PR TITLE
Adjust Naga19 implementation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 
 in progress
 ===========
+- Fix and adjust Naga19 implementation.
+  Use "medium" size as default, which is millisecond granularity.
 
 2023-09-09 0.6.0
 ================

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,7 +56,7 @@ def test_gibberish(capsys):
 
     # Verify output.
     raw = out.strip()
-    assert len(raw) >= 5
+    assert len(raw) >= 4
 
 
 def test_moment(capsys):
@@ -78,7 +78,7 @@ def test_naga19(capsys):
 
     # Verify output.
     raw = out.strip()
-    assert len(raw) >= 10
+    assert len(raw) >= 8
 
 
 def test_slug_sixnibble(capsys):

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,0 +1,23 @@
+from vasuki import generate_nagamani19_hash, generate_nagamani19_int
+
+
+def test_naga19_hash():
+    outcome = generate_nagamani19_hash(size="large")
+    assert len(outcome) >= 10
+
+    outcome = generate_nagamani19_hash(size="medium")
+    assert len(outcome) >= 8
+
+    outcome = generate_nagamani19_hash(size="small")
+    assert len(outcome) >= 6
+
+
+def test_naga19_int():
+    outcome = generate_nagamani19_int(size="large")
+    assert outcome > 10 ** 13
+
+    outcome = generate_nagamani19_int(size="medium")
+    assert outcome > 10 ** 11
+
+    outcome = generate_nagamani19_int(size="small")
+    assert outcome > 10 ** 8

--- a/vasuki/__init__.py
+++ b/vasuki/__init__.py
@@ -4,7 +4,7 @@ __version__ = '0.6.0'
 
 from vasuki.unique.uuid import generate_uuid4
 from vasuki.unique.ulid import generate_ulid
-from vasuki.unique.naga19 import generate_nagamani19, generate_nagamani19_int
+from vasuki.unique.naga19 import generate_nagamani19_hash, generate_nagamani19_int
 from vasuki.unique.gibberish import generate_gibberish
 from vasuki.unique.moment import generate_momentname
 from vasuki.format.sixnibblename.sixnibblename import integer_slug

--- a/vasuki/core.py
+++ b/vasuki/core.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # (c) 2019 Andreas Motl <andreas@terkin.org>
 import logging
-from vasuki import generate_uuid4, generate_ulid, generate_nagamani19, generate_gibberish, integer_slug, generate_momentname
+from vasuki import generate_uuid4, generate_ulid, generate_nagamani19_hash, generate_gibberish, integer_slug, generate_momentname
 
 log = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ class VasukiCommand:
             result = generate_ulid()
 
         elif self.options.naga19:
-            result = generate_nagamani19(size=self.options.size)
+            result = generate_nagamani19_hash(size=self.options.size)
 
         elif self.options.gibberish:
             result = generate_gibberish(size=self.options.size)

--- a/vasuki/unique/naga19.py
+++ b/vasuki/unique/naga19.py
@@ -18,15 +18,15 @@ def generate_nagamani19_obj(size=None) -> Nagamani:
 
 def generate_nagamani19(size=None) -> str:
     warnings.warn(DeprecationWarning("The function `generate_nagamani19` is deprecated. Please use `generate_nagamani19_hash` instead."))
-    return generate_nagamani19_obj().hash()
+    return generate_nagamani19_obj(size=size).hash()
 
 
 def generate_nagamani19_hash(size=None) -> str:
-    return generate_nagamani19_obj().hash()
+    return generate_nagamani19_obj(size=size).hash()
 
 
 def generate_nagamani19_int(size=None) -> int:
-    return generate_nagamani19_obj().duration()
+    return generate_nagamani19_obj(size=size).duration()
 
 
 def get_precision(selector):

--- a/vasuki/unique/naga19.py
+++ b/vasuki/unique/naga19.py
@@ -30,5 +30,5 @@ def generate_nagamani19_int(size=None) -> int:
 
 
 def get_precision(selector):
-    selector = selector or 'large'
+    selector = selector or 'medium'
     return size_map[selector]


### PR DESCRIPTION
- Use "medium" size as default, which is millisecond granularity
- Fix propagating "size" parameter
- Stop using deprecated functions
- Add more test cases